### PR TITLE
Temperature and Humidity Calculation Issue - Fixed by Qualifying Enum Variants in Match

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ impl DhtValue {
     /// All raw data from DHT sensor are related to this scale.
     pub fn temperature(&self) -> f32 {
         match &self.dht_type {
-            DHT11 => self.value[2] as f32,
+            DhtType::DHT11 => self.value[2] as f32,
             _ => {
                 let mut v: f32 = (self.value[2] & 0x7F) as f32;
                 v = (v * 256.0 + self.value[3] as f32) * 0.1;
@@ -143,7 +143,7 @@ impl DhtValue {
     /// Return humidity readins in percents.
     pub fn humidity(&self) -> f32 {
         match &self.dht_type {
-            DHT11 => self.value[0] as f32,
+            DhtType::DHT11 => self.value[0] as f32,
             _ => {
                 let mut v: f32 = self.value[0] as f32;
                 v = (v * 256.0 + self.value[1] as f32) * 0.1;


### PR DESCRIPTION
First, thank for your work on this library. It's been working great for reading my DHT22.

### Issue

The code as-is populates the `DhtValue` struct with the raw `u8`s from my sensor. Calling the `temperature()` or `humidity()` functions results in me being returned either a `0.0` or `1.0` regardless of the underlying raw data in the `DhtValue.value` array.

``` rust
use dht_hal_drv;
use spin_sleep;

# Setup I2C pins

let dht_read = dht_hal_drv::dht_read(dht_hal_drv::DhtType::DHT22, &mut dht22pin, &mut |d| {
                spin_sleep::sleep(time::Duration::from_micros(d as u64));
});
match dht_read {
    Ok(reading) => {
        println!("Reading: {:?}", &reading);
        println!("Temp: {:.1}\t Hum: {:.1}", reading.temperature(), reading.humidity());
    }
    Err(e) => println!("Error: {:?}", e),
}
```

Returns:
```
Reading: DhtValue { dht_type: DHT22, value: [1, 173, 0, 222, 140] }
Temp: 0.0        Hum: 1.0
```

### Fix

Looking in to this I noticed the crate compiles but does emit some warnings:
```
warning[E0170]: pattern binding `DHT11` is named the same as one of the variants of the type `DhtType`
   --> dht-hal-drv/src/lib.rs:125:13
    |
125 |             DHT11 => self.value[2] as f32,
    |             ^^^^^ help: to match on the variant, qualify the path: `DhtType::DHT11`
    |
    = note: `#[warn(bindings_with_variant_name)]` on by default
```
Changing the values in the match statements in the `temperature()` and `humidity()` functions to the fully qualified enum variant addresses these and other warnings:
``` rust
DhtType::DHT11 => self.value[0] as f32,
```
With this in place the output is now as expected:
```
Reading: DhtValue { dht_type: DHT22, value: [1, 176, 0, 221, 142] }
Temp: 22.1       Hum: 43.2
```